### PR TITLE
Improve to pre-load comments, we can now show comments without scrolling.

### DIFF
--- a/script.js
+++ b/script.js
@@ -143,7 +143,6 @@ const newYouTube = {
 
   _addClass() {
     debugLog('ADDING CLASS...');
-    // document.getElementById('comments').classList.add('hide-comments');
     document.querySelector('ytd-item-section-renderer.ytd-comments').classList.add('hide-comments');
   },
 
@@ -166,7 +165,6 @@ const newYouTube = {
 
   _toggleComments() {
     const label = document.getElementById('toggle-comments').firstElementChild;
-    // const comments = document.getElementById('comments');
     const comments = document.querySelector("ytd-item-section-renderer.ytd-comments");
 
     if (comments.classList.toggle('hide-comments')) {

--- a/script.js
+++ b/script.js
@@ -137,14 +137,14 @@ const newYouTube = {
     return (
       typeof e !== 'undefined' &&
       e.type === 'yt-visibility-refresh' &&
-      (e.target.tagName === 'YT-IMG-SHADOW' ||
-        e.target.tagName === 'YTD-VIDEO-SECONDARY-INFO-RENDERER')
+      e.target.tagName === 'YTD-ITEM-SECTION-RENDERER' // this mean: rendered childNode of comments'DOM(ytd-comments)
     );
   },
 
   _addClass() {
     debugLog('ADDING CLASS...');
-    document.getElementById('comments').classList.add('hide-comments');
+    // document.getElementById('comments').classList.add('hide-comments');
+    document.querySelector('ytd-item-section-renderer.ytd-comments').classList.add('hide-comments');
   },
 
   _addButton() {
@@ -166,7 +166,8 @@ const newYouTube = {
 
   _toggleComments() {
     const label = document.getElementById('toggle-comments').firstElementChild;
-    const comments = document.getElementById('comments');
+    // const comments = document.getElementById('comments');
+    const comments = document.querySelector("ytd-item-section-renderer.ytd-comments");
 
     if (comments.classList.toggle('hide-comments')) {
       label.textContent = globals.showComments;

--- a/youtube.css
+++ b/youtube.css
@@ -1,5 +1,6 @@
 .hide-comments {
-  display: none !important;
+  height: 0px;
+  overflow: hidden;
 }
 
 .fake-paper-button {


### PR DESCRIPTION
FIx Issue: #6 

I changed the hide method. comments DOM element doesn't  disappear.
The YouTube's comment loading script doesn't seem to catch fire unless the target DOM (`e.target.tagName === 'YTD-ITEM-SECTION-RENDERER'`) is valid.
It is mean, comments is hide, but enabled in DOM.

please check regard.