### PR TITLE
Bug fix / For oldYouTube, remove padding while comments is hidden

### DIFF
--- a/youtube.css
+++ b/youtube.css
@@ -1,6 +1,7 @@
 .hide-comments {
   height: 0px;
   overflow: hidden;
+  padding: 0 !important; /* this padding for oldYouTube */
 }
 
 .fake-paper-button {


### PR DESCRIPTION
Fix this issue: #16 

In old YouTube, comments box not fully hide 🙇 
Remove padding while contain `hide-comments`.