### PR TITLE
🆕  New feature 🚀 : Display number of comments.

### DIFF
--- a/script.js
+++ b/script.js
@@ -49,6 +49,7 @@ const oldYouTube = {
 
     oldYouTube._addClass();
     oldYouTube._addButton();
+    oldYouTube._waitCommentsPanel();
   },
 
   _ready() {
@@ -65,6 +66,7 @@ const oldYouTube = {
     const button = `
     <button class="yt-uix-button yt-uix-button-size-default yt-uix-button-expander" id="toggle-comments" type="button">
       <span class="yt-uix-button-content">${globals.showComments}</span>
+      &nbsp;<span id="comments-count"></span>
     </button>
     `;
 
@@ -76,7 +78,10 @@ const oldYouTube = {
 
   _toggleComments() {
     const label = document.getElementById('toggle-comments').firstElementChild;
+    const countLabel = document.getElementById('comments-count');
     const comments = document.getElementById('watch-discussion');
+    
+    countLabel.classList.toggle('is-hide'); // toggle commentsCount.
 
     if (comments.classList.toggle('hide-comments')) {
       label.textContent = globals.showComments;
@@ -100,6 +105,38 @@ const oldYouTube = {
         comment.nextElementSibling.classList.remove('hid');
       }
     }
+  },
+
+  _waitCommentsPanel() {
+    debugLog('OBSERVING COMMENTS COUNT...');
+
+    const observerTarget = document.getElementById('watch-discussion');
+    const observerConfig = { childList: true };
+    const commentsPanelObserver = new MutationObserver( mutations => {
+      mutations.some( mutation => {
+        if (mutation.addedNodes.length) {
+          commentsPanelObserver.disconnect();
+          debugLog('OBSERVED COMMENTS PANEL...');
+          oldYouTube._addCommentsCount();
+          return true; // the same as "break" in `Array.some()`
+        }
+      });
+    });
+
+    commentsPanelObserver.observe(observerTarget, observerConfig);
+  },
+
+  _addCommentsCount() {
+    debugLog('FETCH COMMENTS COUNT...');
+    const targetNode = document.getElementsByClassName('comment-section-header-renderer')[0];
+    
+    if (!targetNode) return;
+    const extractDigitArray = targetNode.textContent.match(/\d+/g);
+    const countString = extractDigitArray.join();
+
+    debugLog('ADDING COMMENTS COUNT...');
+    const label = document.getElementById('comments-count');
+    label.textContent = countString;
   },
 };
 

--- a/script.js
+++ b/script.js
@@ -129,8 +129,6 @@ const oldYouTube = {
   _addCommentsCount() {
     debugLog('FETCH COMMENTS COUNT...');
     const targetNode = document.getElementsByClassName('comment-section-header-renderer')[0];
-    
-    if (!targetNode) return;
     const extractDigitArray = targetNode.textContent.match(/\d+/g);
     const countString = extractDigitArray.join();
 
@@ -283,8 +281,6 @@ const newYouTube = {
   _fetchCommentsCount() {
     debugLog('FETCH COMMENTS COUNT...');
     const targetNode = document.querySelector('yt-formatted-string.count-text');
-    if (!targetNode) return;
-
     const extractDigitArray = targetNode.textContent.match(/\d+/g);
     const countString = extractDigitArray.join();
     newYouTube._commentsState.hasGotCount = true;

--- a/script.js
+++ b/script.js
@@ -164,9 +164,7 @@ const newYouTube = {
     <button class="fake-paper-button" id="toggle-comments" ${style} type="button">
       <div class="fake-yt-formatted-string">
         <span id="toggle-comments-label">${globals.showComments}</span>
-        <span id="comments-count-label">
-          (<span id="comments-count">...</span>)
-        </span>
+        &nbsp;<span id="comments-count"></span>
       </div>
     </button>
     `;
@@ -180,7 +178,7 @@ const newYouTube = {
 
   _toggleComments() {
     const buttonLabel = document.getElementById('toggle-comments-label');
-    const countLabel = document.getElementById('comments-count-label');
+    const countLabel = document.getElementById('comments-count');
     const comments = document.querySelector("ytd-item-section-renderer.ytd-comments");
 
     countLabel.classList.toggle('is-hide'); // toggle commentsCount.
@@ -210,7 +208,7 @@ const newYouTube = {
     if (!label) return;
     
     debugLog('REWRITING COMMENTS COUNT...');
-    (condition === 'counting') ? label.textContent = '...'
+    (condition === 'counting') ? label.textContent = ''
                                : label.textContent = newYouTube._commentsInfo.currentCount;
   },
 

--- a/script.js
+++ b/script.js
@@ -150,9 +150,15 @@ const newYouTube = {
     debugLog('ADDING BUTTON...');
     const moreButton = document.getElementById('more');
     const style = moreButton.hidden ? 'style="margin-left:0"' : '';
+    const countOfComments = () => {
+      const node = document.querySelector('yt-formatted-string.count-text')
+      console.log(node.textContent)
+      const count = parseInt(node.textContent, 10);
+      return count
+    };
     const button = `
     <button class="fake-paper-button" id="toggle-comments" ${style} type="button">
-      <span class="fake-yt-formatted-string">${globals.showComments}</span>
+      <span class="fake-yt-formatted-string">${globals.showComments} (${countOfComments()})</span>
     </button>
     `;
 

--- a/script.js
+++ b/script.js
@@ -193,12 +193,12 @@ const newYouTube = {
   injectCommentsCount(e) {
     if (!newYouTube._ready(e)) return;
 
-    newYouTube._commentsInfo.hasGotCount = false;
+    newYouTube._commentsState.hasGotCount = false;
     newYouTube._rewriteCommentsCount('counting');
     newYouTube._waitCommentsCount()
   },
   
-  _commentsInfo: {
+  _commentsState: {
     hasGotCount: false,
     currentCount: '',
   },
@@ -209,11 +209,11 @@ const newYouTube = {
     
     debugLog('REWRITING COMMENTS COUNT...');
     (condition === 'counting') ? label.textContent = ''
-                               : label.textContent = newYouTube._commentsInfo.currentCount;
+                               : label.textContent = newYouTube._commentsState.currentCount;
   },
 
   _waitCommentsCount() {
-    if (newYouTube._commentsInfo.hasGotCount) return;
+    if (newYouTube._commentsState.hasGotCount) return;
     
     debugLog('OBSERVING COMMENTS COUNT...');
 
@@ -250,8 +250,8 @@ const newYouTube = {
 
     const extractDigitArray = targetNode.textContent.match(/\d+/g);
     const countString = extractDigitArray.join();
-    newYouTube._commentsInfo.hasGotCount = true;
-    newYouTube._commentsInfo.currentCount = countString;
+    newYouTube._commentsState.hasGotCount = true;
+    newYouTube._commentsState.currentCount = countString;
     newYouTube._rewriteCommentsCount()
   },
 };

--- a/youtube.css
+++ b/youtube.css
@@ -4,6 +4,10 @@
   padding: 0 !important; /* this padding for oldYouTube */
 }
 
+.is-hide {
+  display: none
+}
+
 .fake-paper-button {
   display: inline-block;
   position: relative;


### PR DESCRIPTION
Topic issue: #20 

I implemented this in parallel with the discussion at the issue.
I tested it on both English and Japanese YouTube and it works fine in my local. I want you to check it too! 🙏 

Also, as I noticed during implementation, there is multiple condition patterns when the original number of comments node is rendered. The extension needs to parse this unstable rendered node, i've used "Mutation Observer" to monitor the node is rendered.

The condition patterns, I'm grasping is below.

* When navigating to the video with the same number of comments
  * e.g. 5 comments video to 5 comments video
  * Measures line `script.js: 268`
* User switch to the next video by auto play when the YouTube's browser tab is set as the background tab. (User is browsing another tab while opening youtube)
  * At the moment of returning to the YouTube tab, the YouTube original script starts to get a comments
  * Measures line `script.js: 154`

I saw many videos with a possible pattern, but this is the only condition of exceptional behavior that I could find. There may be other pattern scenarios (or it may happen suddenly as specification changes) ... 💭 
