### PR TITLE
Compress extension using minify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL = /bin/sh
 INPATH = .
 TIMESTAMP = $(shell date +%F_%H%M)
 OUTPATH = $(TIMESTAMP)-toggle-youtube-comments.zip
+MINIFY_DIR = _build/
 
 .PHONY: help
 help:
@@ -11,8 +12,16 @@ help:
 	@echo "  bump      Changes the version number to the one provided"
 	@echo "  clean     Cleans up all build artifacts"
 
-bundle: $(INPATH)
-	zip -9 -r $(OUTPATH) $(INPATH) -x ".*" "*.md" "*.zip" "Makefile"
+compress: $(INPATH) | $(MINIFY_DIR)
+	minify --recursive $(INPATH) --output $(MINIFY_DIR)
+	cp -r LICENSE icons $(MINIFY_DIR)
+
+$(MINIFY_DIR):
+	mkdir $(MINIFY_DIR)
+
+bundle: compress
+bundle: $(MINIFY_DIR)
+	zip -9 -r $(OUTPATH) $(MINIFY_DIR)
 
 bump: prev_version = $(shell grep '"version":' manifest.json | cut -d\" -f4)
 bump: search = ("version":[[:space:]]*").+(")
@@ -31,4 +40,4 @@ test:
 	@echo Not yet supported
 
 clean:
-	-rm *.zip
+	-rm -r *.zip $(MINIFY_DIR)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ INPATH = .
 TIMESTAMP = $(shell date +%F_%H%M)
 OUTPATH = $(TIMESTAMP)-toggle-youtube-comments.zip
 MINIFY_DIR = _build/
+MINIFY := $(shell command -v minify 2> /dev/null)
 
 .PHONY: help
 help:
@@ -13,8 +14,12 @@ help:
 	@echo "  clean     Cleans up all build artifacts"
 
 compress: $(INPATH) | $(MINIFY_DIR)
+ifneq ($(MINIFY),)
 	minify --recursive $(INPATH) --output $(MINIFY_DIR)
 	cp -r LICENSE icons $(MINIFY_DIR)
+else
+	$(error "minify is not available, please install from https://github.com/tdewolff/minify/tree/master/cmd/minify")
+endif
 
 $(MINIFY_DIR):
 	mkdir $(MINIFY_DIR)


### PR DESCRIPTION
Zipped bundle without minify: 8.1K
Zipped bundle with minify: 7.7K

The savings are not that great, most likely because it doesn't compress the icons and license.
(Note I'm including the license in the bundle because people with a bit of technical knowledge can download the source directly from the Web Store instead of going to GitHub.) 

I also don't like the difficulty of installing this tool which could be a pain point for contributors.