### PR TITLE
Easier version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "compress": "node tasks/compress.js",
     "pack": "node tasks/pack.js",
     "build": "run-s clean compress pack",
-    "version": "node tasks/bump-manifest.js",
+    "version": "node tasks/bump-manifest.js && git add src/manifest.json",
     "release": "echo \"Error: no release specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "compress": "node tasks/compress.js",
     "pack": "node tasks/pack.js",
     "build": "run-s clean compress pack",
-    "bump": "echo \"Error: no bump specified\" && exit 1",
+    "version": "node tasks/bump-manifest.js",
     "release": "echo \"Error: no release specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "pack": "node tasks/pack.js",
     "build": "run-s clean compress pack",
     "version": "node tasks/bump-manifest.js && git add src/manifest.json",
+    "postversion": "git push && git push --tags",
     "release": "echo \"Error: no release specified\" && exit 1"
   },
   "repository": {

--- a/tasks/bump-manifest.js
+++ b/tasks/bump-manifest.js
@@ -1,0 +1,5 @@
+const sed = require('shelljs').sed;
+const oldVersion = require('../src/manifest.json').version;
+const newVersion = require('../package.json').version;
+
+sed('-i', oldVersion, newVersion, 'src/manifest.json');


### PR DESCRIPTION
Automate the process for bumping the extension's version. Can now use `npm-version`.

```
npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]
```

Closes #36 
